### PR TITLE
MyOOSDumper 2.4.18 fixes and changes

### DIFF
--- a/msd/config_overview.php
+++ b/msd/config_overview.php
@@ -189,13 +189,13 @@ if (isset($_POST['save']))
 
 	if (isset($_POST['email_maxsize1'])) $config['email_maxsize1']=$_POST['email_maxsize1'];
 	if ($config['email_maxsize1'] == "") $config['email_maxsize1']=0;
-	if (isset($_POST['selected_config'])) $config['email_maxsize2']=$_POST['email_maxsize2'];
+	if (isset($_POST['email_maxsize2'])) $config['email_maxsize2']=$_POST['email_maxsize2'];
 	$config['email_maxsize']=$config['email_maxsize1'] * ( ( $config['email_maxsize2'] == 1 ) ? 1024 : 1024 * 1024 );
 
 	if (isset($_POST['memory_limit'])) $config['memory_limit']=$_POST['memory_limit'];
 	if ($config['memory_limit'] == "") $config['memory_limit']=0;
 	if (isset($_POST['minspeed'])) $config['minspeed']=$_POST['minspeed'];
-	if ($config['minspeed'] < 50) $config['minspeed']=50;
+	if ($config['minspeed'] < 5) $config['minspeed']=5;
 	if (isset($_POST['maxspeed'])) $config['maxspeed']=$_POST['maxspeed'];
 	if ($config['maxspeed'] < $config['minspeed']) $config['maxspeed']=$config['minspeed'] * 2;
  	if (isset($_POST['stop_with_error'])) $config['stop_with_error']=$_POST['stop_with_error'];
@@ -307,7 +307,7 @@ if (isset($_POST['save']))
 	$config['ftp_user']=array();
 	$config['ftp_pass']=array();
 	$config['ftp_dir']=array();
-	
+
 	for ($i=0; $i < 3; $i++)
 	{
 		$checkFTP[$i]="";
@@ -817,8 +817,8 @@ $aus['global1'].='<td><input type="text" class="text" size="6" name="minspeed" m
 $aus['global1'].='</table></fieldset><fieldset><legend>' . $lang['L_DUMP'] . '</legend><table>';
 
 $aus['global1'].='<tr><td>' . Help($lang['L_HELP_ZIP'],"conf3") . $lang['L_GZIP'] . ':&nbsp;</td>';
-$aus['global1'].='<td><input type="radio" class="radio" value="1" name="compression" ' . ( ( $config['zlib'] ) ? '' : 'disabled' ) . ( (isset($config['logcompression']) && ($config['logcompression'] == 1) ) ? " checked" : "" ) . '>&nbsp;' . $lang['L_ACTIVATED'];
-$aus['global1'].='&nbsp;&nbsp;&nbsp;<input type="radio" class="radio" value="0" name="compression" ' . ( (isset($config['logcompression']) && ($config['logcompression'] == 0) ) ? " checked" : "" ) . '>&nbsp;' . $lang['L_NOT_ACTIVATED'] . '</td></tr>';
+$aus['global1'].='<td><input type="radio" class="radio" value="1" name="compression" ' . ( ( $config['zlib'] ) ? '' : 'disabled' ) . ( (isset($config['compression']) && ($config['compression'] == 1) ) ? " checked" : "" ) . '>&nbsp;' . $lang['L_ACTIVATED'];
+$aus['global1'].='&nbsp;&nbsp;&nbsp;<input type="radio" class="radio" value="0" name="compression" ' . ( (isset($config['compression']) && ($config['compression'] == 0) ) ? " checked" : "" ) . '>&nbsp;' . $lang['L_NOT_ACTIVATED'] . '</td></tr>';
 //Multipart-Backup -->
 $aus['global1'].='<tr><td>' . Help($lang['L_HELP_MULTIPART'],"") . $lang['L_MULTI_PART'] . ':&nbsp;</td><td>';
 $aus['global1'].='<input type="radio" class="radio" value="1" name="multi_part" onclick="obj_enable(\'multipartgroesse1\');obj_enable(\'multipartgroesse2\');" ' . ( (isset($config['multi_part']) && ( $config['multi_part'] == 1 ) ) ? " checked" : "" ) . '>&nbsp;' . $lang['L_YES'];

--- a/msd/inc/home/databases.php
+++ b/msd/inc/home/databases.php
@@ -134,7 +134,7 @@ if (isset($_GET['dbid']))
 	if ($numrows>0)
 	{
 		$last_update="2000-01-01 00:00:00";
-		$sum_records=$sum_data_length='';
+		$sum_records=$sum_data_length=0;
 		for ($i=0; $i<$numrows; $i++)
 		{
 			$row=mysqli_fetch_array($res,MYSQLI_ASSOC);


### PR DESCRIPTION
Fixes:
* If a DB is selected with "Home > Databases", 2 PHP errors are caused.
* In the config page "General" with "Backup > GZip compression:" a changed state is not saved. Instead, the state is influenced by "compressed (gz)". Both errors have the same cause.
* In the config page "Email" for "Maximum size of attachment:" the unit of measure (KB / MB) cannot be changed or saved permanently.

Changes:
* In the "General" config page, the minimum value 5 is accepted for "Speed control". So far there have been 50, which is too much for some servers in connection with certain DBs (such as MantisBT). This gives you more leeway in the settings to be able to carry out successful backups even in special cases.