### PR TITLE
MyOOSDumper 5.0.1 compatibility fix

### DIFF
--- a/msd/inc/sqlbrowser/mysql_search.php
+++ b/msd/inc/sqlbrowser/mysql_search.php
@@ -64,7 +64,7 @@ function mysqli_search($db, $tabelle, $suchbegriffe, $suchart, $offset=0, $anzah
 				if (trim($suchworte[$i])=='') unset($suchworte[$i]);
 			}
 
-			$bedingung='';
+			$bedingung=array();
 			$where='';
 			$felder='';
 


### PR DESCRIPTION
* If an attempt was made to use the search in the SQL browser, it generated PHP errors. The cause was an array which was initialized with an empty string. This is not allowed as of PHP 7.1 and causes a serious error.