### PR TITLE
MyOOSDumper 5.0.1 compatibility adjustments and fixes #2

### DIFF
--- a/msd/language/ar/lang_sql.php
+++ b/msd/language/ar/lang_sql.php
@@ -159,11 +159,9 @@ $lang['L_SEARCH_OPTIONS_OR']="يجب ان يحتوي العمود على احد�
 $lang['L_SEARCH_OPTIONS_CONCAT']="الصف يجب ان يحتوي على كل كلمات البحث ولكن يمكن ان يكونوا في اي عمود(يمكن ان يستغرق بعض الوقت)";
 $lang['L_SEARCH_OPTIONS_AND']="العمود يجب ان يحتوي على جميع كلمات البحث  (و-البحث)";
 $lang['L_SEARCH_IN_TABLE']="بحث في الجدول";
+$lang['L_ERROR_NO_FIELDS']="Search error: it could not be determined which fields the table \"%s\" has!";
 $lang['L_SQL_EDIT_TABLESTRUCTURE']="تحرير اعمدة الجدول";
-$lang['L_DEFAULT_CHARSET']="الاعدادات الاصلية
-
-
-";
+$lang['L_DEFAULT_CHARSET']="الاعدادات الاصلية";
 $lang['L_TITLE_KEY_PRIMARY']="المفتاح الاساسي";
 $lang['L_TITLE_KEY_UNIQUE']="مفتاح فريد";
 $lang['L_TITLE_INDEX']="الرئيسة";
@@ -171,10 +169,7 @@ $lang['L_TITLE_KEY_FULLTEXT']="مفتاح النص الكامل";
 $lang['L_TITLE_NOKEY']="لا مفتاح";
 $lang['L_TITLE_SEARCH']="بحث";
 $lang['L_TITLE_MYSQL_HELP']="MySQl وثائق";
-$lang['L_TITLE_UPLOAD']="ارسال ملف SQL
-
-
-";
+$lang['L_TITLE_UPLOAD']="ارسال ملف SQL";
 $lang['L_PRIMARYKEY_DELETED']="Primary key deleted";
 $lang['L_PRIMARYKEY_NOTFOUND']="Primary key not found";
 $lang['L_PRIMARYKEYS_CHANGED']="Primary keys changed";

--- a/msd/language/ch/lang_sql.php
+++ b/msd/language/ch/lang_sql.php
@@ -159,6 +159,7 @@ $lang['L_SEARCH_OPTIONS_OR']="e Spalte mues mindeschtens ein Suechbegriff enthal
 $lang['L_SEARCH_OPTIONS_CONCAT']="en Datesatz mues alli Suechbegriffe enthalte, diä chöned aber i beliebige Spalte sii (Recheintensiv!)";
 $lang['L_SEARCH_OPTIONS_AND']="e Spalte mues alli Suechbegriff enthalte (UND-Suche)";
 $lang['L_SEARCH_IN_TABLE']="Suech i de Tabälle";
+$lang['L_ERROR_NO_FIELDS']="Search error: it could not be determined which fields the table \"%s\" has!";
 $lang['L_SQL_EDIT_TABLESTRUCTURE']="Tabällestruktur bearbeite";
 $lang['L_DEFAULT_CHARSET']="Standardzeichesatz";
 $lang['L_TITLE_KEY_PRIMARY']="Primärschlüssel";

--- a/msd/language/da/lang_sql.php
+++ b/msd/language/da/lang_sql.php
@@ -159,6 +159,7 @@ $lang['L_SEARCH_OPTIONS_OR']="en kolonne skal indeholde et af søgeordene (ELLER
 $lang['L_SEARCH_OPTIONS_CONCAT']="en række skal indeholde alle søgeordene men kan være i hvilkensomhelst kolonne (kan tage noget tid)";
 $lang['L_SEARCH_OPTIONS_AND']="en kolonne skal indeholde ALLE søgeord (OG-søgning)";
 $lang['L_SEARCH_IN_TABLE']="Søg i tabel";
+$lang['L_ERROR_NO_FIELDS']="Search error: it could not be determined which fields the table \"%s\" has!";
 $lang['L_SQL_EDIT_TABLESTRUCTURE']="Edit table structure";
 $lang['L_DEFAULT_CHARSET']="Default character set";
 $lang['L_TITLE_KEY_PRIMARY']="Primary key";

--- a/msd/language/de/lang_sql.php
+++ b/msd/language/de/lang_sql.php
@@ -159,6 +159,7 @@ $lang['L_SEARCH_OPTIONS_OR']="eine Spalte muss mindestens einen Suchbegriff enth
 $lang['L_SEARCH_OPTIONS_CONCAT']="ein Datensatz muss alle Suchbegriffe enthalten, diese können aber in beliebigen Spalten sein (Rechenintensiv!)";
 $lang['L_SEARCH_OPTIONS_AND']="eine Spalte muss alle Suchbegriffe enthalten (UND-Suche)";
 $lang['L_SEARCH_IN_TABLE']="Suche in Tabelle";
+$lang['L_ERROR_NO_FIELDS']="Fehler bei Suche: es konnte nicht ermittelt werden, welche Felder die Tabelle \"%s\" hat!";
 $lang['L_SQL_EDIT_TABLESTRUCTURE']="Tabellenstruktur bearbeiten";
 $lang['L_DEFAULT_CHARSET']="Standardzeichensatz";
 $lang['L_TITLE_KEY_PRIMARY']="Primärschlüssel";

--- a/msd/language/de_du/lang_sql.php
+++ b/msd/language/de_du/lang_sql.php
@@ -159,6 +159,7 @@ $lang['L_SEARCH_OPTIONS_OR']="eine Spalte muss mindestens einen Suchbegriff enth
 $lang['L_SEARCH_OPTIONS_CONCAT']="ein Datensatz muss alle Suchbegriffe enthalten, diese können aber in beliebigen Spalten sein (Rechenintensiv!)";
 $lang['L_SEARCH_OPTIONS_AND']="eine Spalte muss alle Suchbegriffe enthalten (UND-Suche)";
 $lang['L_SEARCH_IN_TABLE']="Suche in Tabelle";
+$lang['L_ERROR_NO_FIELDS']="Fehler bei Suche: es konnte nicht ermittelt werden, welche Felder die Tabelle \"%s\" hat!";
 $lang['L_SQL_EDIT_TABLESTRUCTURE']="Tabellenstruktur bearbeiten";
 $lang['L_DEFAULT_CHARSET']="Standardzeichensatz";
 $lang['L_TITLE_KEY_PRIMARY']="Primärschlüssel";

--- a/msd/language/el/lang_sql.php
+++ b/msd/language/el/lang_sql.php
@@ -159,6 +159,7 @@ $lang['L_SEARCH_OPTIONS_OR']="Η στήλη πρέπει να έχει τουλ�
 $lang['L_SEARCH_OPTIONS_CONCAT']="Η γραμμή πρέπει περιλαμβάνει όλες τις λέξεις αναζήτησης αλλά μπορεί να είναι σε κάποια στήλη (χρειάζεται λίγο χρόνο)";
 $lang['L_SEARCH_OPTIONS_AND']="Η γραμμή πρέπει περιλαμβάνει όλες τις λέξεις αναζήτησης (AND-search)";
 $lang['L_SEARCH_IN_TABLE']="Αναζήτηση στον πίνακα";
+$lang['L_ERROR_NO_FIELDS']="Search error: it could not be determined which fields the table \"%s\" has!";
 $lang['L_SQL_EDIT_TABLESTRUCTURE']="Επεξεργασία δομής πίνακα";
 $lang['L_DEFAULT_CHARSET']="Προεπιλεγμένο σετ χαρακτήρων";
 $lang['L_TITLE_KEY_PRIMARY']="Πρωτεύων κλειδί";
@@ -168,10 +169,7 @@ $lang['L_TITLE_KEY_FULLTEXT']="Κλειδί πλήρη κειμένου";
 $lang['L_TITLE_NOKEY']="Κανένα κλειδί";
 $lang['L_TITLE_SEARCH']="Αναζήτηση";
 $lang['L_TITLE_MYSQL_HELP']="Τεκμηρίωση MySQl";
-$lang['L_TITLE_UPLOAD']="Φόρτωση αρχείου SQL
-
-
-";
+$lang['L_TITLE_UPLOAD']="Φόρτωση αρχείου SQL";
 $lang['L_PRIMARYKEY_DELETED']="Το πρωτεύων κλειδί διαγράφηκε";
 $lang['L_PRIMARYKEY_NOTFOUND']="Δε βρέθηκε πρωτεύων κλειδί";
 $lang['L_PRIMARYKEYS_CHANGED']="Τα πρωτεύοντα κλειδιά άλλαξαν";

--- a/msd/language/en/lang_sql.php
+++ b/msd/language/en/lang_sql.php
@@ -159,6 +159,7 @@ $lang['L_SEARCH_OPTIONS_OR']="a column must have one of the search words (OR-sea
 $lang['L_SEARCH_OPTIONS_CONCAT']="a row must contain all of the search words but they can be in any column (could take some time)";
 $lang['L_SEARCH_OPTIONS_AND']="a column must contain all search words (AND-search)";
 $lang['L_SEARCH_IN_TABLE']="Search in table";
+$lang['L_ERROR_NO_FIELDS']="Search error: it could not be determined which fields the table \"%s\" has!";
 $lang['L_SQL_EDIT_TABLESTRUCTURE']="Edit table structure";
 $lang['L_DEFAULT_CHARSET']="Default character set";
 $lang['L_TITLE_KEY_PRIMARY']="Primary key";

--- a/msd/language/es/lang_sql.php
+++ b/msd/language/es/lang_sql.php
@@ -154,13 +154,12 @@ $lang['L_SEARCH_OPTIONS']="Opciones de búsqueda";
 $lang['L_SEARCH_RESULTS']="La búsqueda para \"<b>%s</b>\" en la tabla \"<b>%s</b>\" produjo los siguientes resultados";
 $lang['L_SEARCH_NO_RESULTS']="¡La búsqueda para \"<b>%s</b>\" en la tabla \"<b>%s</b>\" no produjo ningún resultado!";
 $lang['L_NO_ENTRIES']="La tabla \"<b>%s</b>\" está vacía y no contiene ninguna entrada.";
-$lang['L_SEARCH_ACCESS_KEYS']="Navegar:
-Adelante=ALT+V
-Atrás=ALT+C";
+$lang['L_SEARCH_ACCESS_KEYS']="Navegar: Adelante=ALT+V, Atrás=ALT+C";
 $lang['L_SEARCH_OPTIONS_OR']="Una columna debe contener al menos un criterio de búsqueda (O-Búsqueda)";
 $lang['L_SEARCH_OPTIONS_CONCAT']="Una línea debe contener todos los términos de búsqueda, pero estos puede ser en cualquiera de las columnas (¡podría tardar!)";
 $lang['L_SEARCH_OPTIONS_AND']="una columna debe contener todos los términos de búsqueda (Y-Búsqueda)";
 $lang['L_SEARCH_IN_TABLE']="Buscar en la tabla";
+$lang['L_ERROR_NO_FIELDS']="Search error: it could not be determined which fields the table \"%s\" has!";
 $lang['L_SQL_EDIT_TABLESTRUCTURE']="Modificar la estructura de la tabla";
 $lang['L_DEFAULT_CHARSET']="Conjunto de caracteres por defecto";
 $lang['L_TITLE_KEY_PRIMARY']="Clave principal";

--- a/msd/language/fr/lang_sql.php
+++ b/msd/language/fr/lang_sql.php
@@ -154,14 +154,12 @@ $lang['L_SEARCH_OPTIONS']="Options de recherches";
 $lang['L_SEARCH_RESULTS']="La recherche pour \"<b>%s</b>\" dans la table \"<b>%s</b>\" a donné les résultats suivants.";
 $lang['L_SEARCH_NO_RESULTS']="Aucun résultat pour la recherche de \"<b>%s</b>\" dans la table \"<b>%s</b>\" !";
 $lang['L_NO_ENTRIES']="La table \"<b>%s</b>\" est vide ou ne contient aucune entrée.";
-$lang['L_SEARCH_ACCESS_KEYS']="Parcourir:
-Vers l'avant:ALT+V,
-Vers l'arrière:ALT+C";
-$lang['L_SEARCH_OPTIONS_OR']="une colonne doit contenir au moins un critère de recherche
-(OU-Recherche)";
+$lang['L_SEARCH_ACCESS_KEYS']="Parcourir: Vers l'avant:ALT+V, Vers l'arrière:ALT+C";
+$lang['L_SEARCH_OPTIONS_OR']="une colonne doit contenir au moins un critère de recherche (OU-Recherche)";
 $lang['L_SEARCH_OPTIONS_CONCAT']="une ligne doit contenir tous les critères de recherche, mais ceux-ci peuvent toutefois être indiqués dans n'importe quelle colonne (Peut prendre du temps de calcul !)";
 $lang['L_SEARCH_OPTIONS_AND']="une colonne doit contenir tous les critères de recherche (ET-Recherche)";
 $lang['L_SEARCH_IN_TABLE']="Rechercher dans la table";
+$lang['L_ERROR_NO_FIELDS']="Search error: it could not be determined which fields the table \"%s\" has!";
 $lang['L_SQL_EDIT_TABLESTRUCTURE']="Modifier la structure des tables";
 $lang['L_DEFAULT_CHARSET']="Jeux de caractères par défaut";
 $lang['L_TITLE_KEY_PRIMARY']="Clé primaire";

--- a/msd/language/it/lang_sql.php
+++ b/msd/language/it/lang_sql.php
@@ -159,6 +159,7 @@ $lang['L_SEARCH_OPTIONS_OR']="una colonna deve contenere almeno una parola di ri
 $lang['L_SEARCH_OPTIONS_CONCAT']="un record deve contenere tutte le parole di ricerca, però possono essere in colonne diverse (Calcolo intensivo!)";
 $lang['L_SEARCH_OPTIONS_AND']="una colonna deve contenere tutte le parole di ricerca";
 $lang['L_SEARCH_IN_TABLE']="cerca nelle tabelle";
+$lang['L_ERROR_NO_FIELDS']="Search error: it could not be determined which fields the table \"%s\" has!";
 $lang['L_SQL_EDIT_TABLESTRUCTURE']="Edit struttura tabelle";
 $lang['L_DEFAULT_CHARSET']="Set di caretteri standard";
 $lang['L_TITLE_KEY_PRIMARY']="Chiave primaria";

--- a/msd/language/pt_br/lang_sql.php
+++ b/msd/language/pt_br/lang_sql.php
@@ -159,6 +159,7 @@ $lang['L_SEARCH_OPTIONS_OR']="a coluna deve conter uma das palavras a pesquisar 
 $lang['L_SEARCH_OPTIONS_CONCAT']="a linha deve conter todas as palavras a pesquisar, mas elas podem estar em qualquer coluna (pode levar algum tempo)";
 $lang['L_SEARCH_OPTIONS_AND']="a coluna deve conter todas as palavras a pesquisar (E-pesquisar)";
 $lang['L_SEARCH_IN_TABLE']="Pesquisar na tabela";
+$lang['L_ERROR_NO_FIELDS']="Search error: it could not be determined which fields the table \"%s\" has!";
 $lang['L_SQL_EDIT_TABLESTRUCTURE']="Edit table structure";
 $lang['L_DEFAULT_CHARSET']="Default character set";
 $lang['L_TITLE_KEY_PRIMARY']="Primary key";

--- a/msd/language/sw/lang_sql.php
+++ b/msd/language/sw/lang_sql.php
@@ -159,6 +159,7 @@ $lang['L_SEARCH_OPTIONS_OR']="en kolumn måste innehålla minst ett sökord (ELL
 $lang['L_SEARCH_OPTIONS_CONCAT']="en datapost måste innehålla alla sökord, dessa kan dock befinna sig i olika kolumner (stor serverbelastning!)";
 $lang['L_SEARCH_OPTIONS_AND']="en kolumn måste innehålla alla sökord (OCH-sökning)";
 $lang['L_SEARCH_IN_TABLE']="Sök i tabell";
+$lang['L_ERROR_NO_FIELDS']="Search error: it could not be determined which fields the table \"%s\" has!";
 $lang['L_SQL_EDIT_TABLESTRUCTURE']="Bearbeta tabellens struktur";
 $lang['L_DEFAULT_CHARSET']="Standardteckensats";
 $lang['L_TITLE_KEY_PRIMARY']="Primär nyckel";

--- a/msd/language/tr/lang_sql.php
+++ b/msd/language/tr/lang_sql.php
@@ -159,6 +159,7 @@ $lang['L_SEARCH_OPTIONS_OR']="Sütunda en azından bir aranılan kelime bulunmal
 $lang['L_SEARCH_OPTIONS_CONCAT']="Metin'de bütün aranılan kelimeler bir satırda bulunmalıdır, fakat aranılan kelimeler değişik sütunlarda bulunabilir. (Vakit alıcı)";
 $lang['L_SEARCH_OPTIONS_AND']="Sütunun içinde aranan kelimelerin hepsi bulunmalı (VE)";
 $lang['L_SEARCH_IN_TABLE']="Tablonun içinde ara";
+$lang['L_ERROR_NO_FIELDS']="Search error: it could not be determined which fields the table \"%s\" has!";
 $lang['L_SQL_EDIT_TABLESTRUCTURE']="Tablo yapısını düzenle";
 $lang['L_DEFAULT_CHARSET']="standart karakter seti";
 $lang['L_TITLE_KEY_PRIMARY']="İndeks";

--- a/msd/language/vn/lang_sql.php
+++ b/msd/language/vn/lang_sql.php
@@ -159,11 +159,9 @@ $lang['L_SEARCH_OPTIONS_OR']="Mỗi cột phải có 1 từ khóa (OR-search)";
 $lang['L_SEARCH_OPTIONS_CONCAT']="một dòng phải chứa tất cả các từ khóa trừ phi họ có thể trong bất kỳ cột nào (thỉnh thoảng có thể ngoại lệ)";
 $lang['L_SEARCH_OPTIONS_AND']="cột phải chứa tất cả từ khóa (AND-search)";
 $lang['L_SEARCH_IN_TABLE']="Tìm trong Bảng";
+$lang['L_ERROR_NO_FIELDS']="Search error: it could not be determined which fields the table \"%s\" has!";
 $lang['L_SQL_EDIT_TABLESTRUCTURE']="Sửa cấu trúc bảng";
-$lang['L_DEFAULT_CHARSET']="Đặt bảng làm mặc định
-
-
-";
+$lang['L_DEFAULT_CHARSET']="Đặt bảng làm mặc định";
 $lang['L_TITLE_KEY_PRIMARY']="Primary key";
 $lang['L_TITLE_KEY_UNIQUE']="Unique key";
 $lang['L_TITLE_INDEX']="Index";


### PR DESCRIPTION
Fixes:
* In the search function of the SQL browser there was another array variable that was initially declared as a string. However, further changes were necessary to correct this error.
* The error handling of the search function was incomplete. If, for whatever reason, no fields in the table could be determined, an error message was only issued for the first two search options, but not for the third.
* If the error (no fields) occurred, the search function could no longer be used in the current PHP session. In this case, the search term is automatically deleted in the session object so that the search function can be called up again via the menu.

Changes:
* The error message regarding missing table fields was defined directly in the source. Instead, the new language variable `L_ERROR_NO_FIELDS` was added and the error message was transferred to the language file (all languages).